### PR TITLE
Free-text search by short team name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ remote-data/*
 *.cli-real-favicon.*
 public/favicons/*
 .vercel
+
+# VS Code
+.devcontainer
+.vscode

--- a/features/PlayersExplorer/usePlayersFilterAndSort.ts
+++ b/features/PlayersExplorer/usePlayersFilterAndSort.ts
@@ -34,6 +34,10 @@ const freeTextFuseSettings: Fuse.IFuseOptions<Player> = {
       name: "web_name",
       weight: 0.7,
     },
+    {
+      name: "team.short_name",
+      weight: 0.5
+    },
   ],
 };
 


### PR DESCRIPTION
Nice set of tools, thanks for putting them out there!

Sometimes I am after a player from a specific team and looking to compare them, so added to the free text search. Totally up to you if you want to accept it or go a different path 😄 

Could be better to do an exact match on this field, and maybe you have bigger plans for filtering as I can see there is already scaffolding for filter objects vs free text etc.
Also just took a total guess on the weight to give it!