### PR TITLE
Bug/Enhancement: made scripts cross platform friendly

### DIFF
--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -3,9 +3,9 @@
   "version": "1.2.0-pre.5",
   "license": "Apache-2.0",
   "scripts": {
-    "init-data": "ts-node -O '{\"module\":\"commonjs\"}' -r tsconfig-paths/register scripts/init-data.ts",
-    "init-links": "ts-node -O '{\"module\":\"commonjs\"}' -r tsconfig-paths/register scripts/init-links.ts",
-    "print-links": "ts-node -O '{\"module\":\"commonjs\"}' -r tsconfig-paths/register scripts/print-links.ts",
+    "init-data": "ts-node -O {\\\"module\\\":\\\"commonjs\\\"} -r tsconfig-paths/register scripts/init-data.ts",
+    "init-links": "ts-node -O {\\\"module\\\":\\\"commonjs\\\"} -r tsconfig-paths/register scripts/init-links.ts",
+    "print-links": "ts-node -O {\\\"module\\\":\\\"commonjs\\\"} -r tsconfig-paths/register scripts/print-links.ts",
     "prebuild": "yarn init-data",
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
- windows does not like the single quotations in `'{\"module\":\"commonjs\"}'`
  - throws a `SyntaxError: Unexpected token ' in JSON at position 0`
- here's a [link](https://github.com/TypeStrong/ts-node/issues/606) for more reading on same problem by other ppl
- I've tested `{\\\"module\\\":\\\"commonjs\\\"}` escaping and it works on both window and mac. Didn't test on linux